### PR TITLE
Making the map side bar work with screens on small mobiles

### DIFF
--- a/frontend/landing-page/css/variation.css
+++ b/frontend/landing-page/css/variation.css
@@ -204,7 +204,7 @@ span.need {
 }
 
 /* Turn off parallax scrolling for phones */
-@media only screen and (max-device-width: 576px) {
+@media only screen and (max-device-width: 1366px) {
   .parallax {
     background-attachment: scroll;
   }

--- a/frontend/map/css/map.css
+++ b/frontend/map/css/map.css
@@ -3,6 +3,28 @@
   --support: #225fb3;
   --needs: #dd1661;
   --deselected: #e8e8e8;
+  --logo-red: #c32b38;
+  --logo-mid-blue: #3781ff;
+  --logo-yellow-green: #d6df45;
+  --logo-mid-green: #4c8b44;
+  --logo-dark-green: #337541;
+  --logo-light-gray: #cccccc;
+  --logo-dark-blue: #001d95;
+  --sidebar-width: 400px;
+}
+
+/* Narrow sidebar for mobile */
+/* @media only screen and (max-device-width: 576px) { */
+@media only screen and (max-device-width: 399px) {
+  :root {
+    --sidebar-width: 360px;
+  }
+}
+
+@media only screen and (max-device-width: 359px) {
+  :root {
+    --sidebar-width: 320px;
+  }
 }
 
 .ui.support.header {
@@ -47,8 +69,10 @@
 }
 
 #plot-area {
-  height: 365px;
-  width: 400px;
+  /* height: 365px;
+  width: 400px; */
+  height: calc(var(--sidebar-width) - 35px);
+  width: var(--sidebar-width);
   z-index: 6;
   /* padding-left: 12px; */
   font-family: Lato,'Helvetica Neue',Arial,Helvetica,sans-serif;
@@ -86,7 +110,8 @@
 
 #sidebar {
   z-index: 5;
-  width: 400px;
+  /* width: 400px; */
+  width: var(--sidebar-width);
   /* height: 100vh; */
   position: absolute;
   top: 0px;
@@ -114,7 +139,8 @@
 
 #sidebar div.select_container {
   /* height: 40px; */
-  width: 380px;
+  /* width: 380px; */
+  width: calc(var(--sidebar-width) - 20px);
   margin: 10px;
   border: solid 1px #000000;
   border-radius: 6px;
@@ -183,11 +209,13 @@ div.select_container h4 {
   background-color: #ffffff;
   padding-left: 2px;
   padding-right: 2px;
-  color: #a2a2a2;
+  /* color: #a2a2a2; */
+  color: var(--logo-mid-green);
 }
 
 #sidebar div i.help:hover {
-  color: #4c4c4c;
+  /* color: #4c4c4c; */
+  color: var(--logo-dark-green);
 }
 
 #sidebar div#support_container i.help {
@@ -198,7 +226,7 @@ div.select_container h4 {
 
 #sidebar div#plot-container i.help {
   position: absolute;
-  right: 6px;
+  right: 14px;
   top: 1px;
 }
 
@@ -210,7 +238,8 @@ div.select_container h4 {
 
 #colour_scale {
   height: 40px;
-  width: 400px;
+  /* width: 400px; */
+  width: var(--sidebar-width);
   position: relative;
 }
 
@@ -229,12 +258,14 @@ div.select_container h4 {
 }
 
 div#multi-select_support {
-  width: 368px;
+  /* width: 368px; */
+  width: calc(var(--sidebar-width) - 32px);
   margin: 12px 5px 12px 5px;
 }
 
 div#multi-select_needs {
-  width: 368px;
+  /* width: 368px; */
+  width: calc(var(--sidebar-width) - 32px);
   margin: 12px 5px 12px 5px;
 }
 
@@ -253,6 +284,7 @@ circle.hovered {
   /* r: 10px; */
   stroke-width: 3px;
 }
+
 
 /* Map */
 #map {

--- a/frontend/map/css/map.css
+++ b/frontend/map/css/map.css
@@ -10,11 +10,17 @@
   --logo-dark-green: #337541;
   --logo-light-gray: #cccccc;
   --logo-dark-blue: #001d95;
-  --sidebar-width: 400px;
+  --sidebar-width: 440px;
 }
 
 /* Narrow sidebar for mobile */
 /* @media only screen and (max-device-width: 576px) { */
+@media only screen and (max-device-width: 879px) {
+  :root {
+    --sidebar-width: 400px;
+  }
+}
+
 @media only screen and (max-device-width: 399px) {
   :root {
     --sidebar-width: 360px;

--- a/frontend/map/js/cc.js
+++ b/frontend/map/js/cc.js
@@ -93,8 +93,6 @@ const cc = (function(d3){
       means[element] = d3.mean(data, d => d[element]);
       sds[element] = d3.deviation(data, d => d[element]);
     });
-    console.log(means);
-    console.log(sds);
     data.forEach(element => {
       element.z_scores = [];
       vars.forEach((item, idx) => {
@@ -690,18 +688,18 @@ const cc = (function(d3){
   } // end redraw
 
   // Colour ramp function adapted from https://observablehq.com/@mbostock/color-ramp
-  function ramp(plot_area, color, n = 380) {
+  function ramp(plot_area, color, width) {
     const canvas = d3.select(plot_area).append("canvas")
       .attr("id", "canvas")
-      .attr("width", 380)
+      .attr("width", width)
       .attr("height", 10)
       .style("position", "absolute")
       .style("bottom", "5px")
       .style("left", "10px")
       .style("imageRendering", "crisp-edges");
     const context = canvas.node().getContext("2d");
-    for (let i = 0; i < n; ++i) {
-      context.fillStyle = color(i / (n - 1));
+    for (let i = 0; i < width; ++i) {
+      context.fillStyle = color(i / (width - 1));
       context.fillRect(i, 0, 1, 10);
     }
     return canvas;

--- a/frontend/map/js/map.js
+++ b/frontend/map/js/map.js
@@ -1,5 +1,16 @@
 // Set up sidebar
-const sidebarWidth = 400;
+let sidebarWidth = 400;
+
+// Set sidebar width for smaller screens
+const sb = window.matchMedia("(max-width: 399px)");
+if (sb.matches) {
+    sidebarWidth = 360;
+}
+
+const sbvs = window.matchMedia("(max-width: 359px)");
+if (sb.matches) {
+    sidebarWidth = 320;
+}
 
 // Opener / closer for sidebar
 const addToggle = cc.getToggleAdder();
@@ -14,8 +25,12 @@ if (mq.matches) {
 }
 
 // Set up plotting area
-const width=400;
-const height=365;
+// const width=400;
+// const height=365;
+
+const width = sidebarWidth;
+const height = sidebarWidth - 35;;
+
 // const margin = ({top: 30, right: 20, bottom: 40, left: 40});
 const margin = ({top: 10, right: 22, bottom: 25, left: 48});
 
@@ -25,7 +40,7 @@ d3.select("#plot-container").append("div")
   .style("opacity", 0);
 
 // Add a color ramp legend
-cc.ramp("#colour_scale", cc.getColourScale([0,1]));
+cc.ramp("#colour_scale", cc.getColourScale([0,1]), sidebarWidth - 20);
 
 // Load json data structure
 const data_promise = d3.json("./frontend/map/data/data.json");

--- a/frontend/map/js/map.js
+++ b/frontend/map/js/map.js
@@ -1,13 +1,18 @@
 // Set up sidebar
-let sidebarWidth = 400;
+let sidebarWidth = 440;
+
+let sb = window.matchMedia("(max-width: 879px)");
+if (sb.matches) {
+    sidebarWidth = 400;
+}
 
 // Set sidebar width for smaller screens
-const sb = window.matchMedia("(max-width: 399px)");
+sb = window.matchMedia("(max-width: 399px)");
 if (sb.matches) {
     sidebarWidth = 360;
 }
 
-const sbvs = window.matchMedia("(max-width: 359px)");
+sb = window.matchMedia("(max-width: 359px)");
 if (sb.matches) {
     sidebarWidth = 320;
 }

--- a/index.html
+++ b/index.html
@@ -284,6 +284,11 @@
       </div>
       <div class="modal-body">
         <p>
+          Datblygwyd y wefan hon gan Brifysgol Bryste gydag adborth gan Iechyd Cyhoeddus Cymru; nid yw’n eiddo
+          i Iechyd Cyhoeddus Cymru ac felly’n cadw at Safonau’r Gymraeg. Fodd bynnag, mae fersiwn Cymraeg yn cael
+          ei ddatblygu.  Oherwydd yr angen am ymagwedd hyblyg tuag at waith yn ystod y cyfnod digynsail hwn, caiff
+          ei phrofi a’i chyhoeddi yn dilyn adborth ac ar ôl mireinio’r wefan bresennol.
+          <hr></hr>
           This website has been developed by the University of Bristol with feedback from Public Health Wales;
           it does not belong to Public Health Wales and so does not currently observe the Welsh Language Standards.
           However, a Welsh language version is in development. Due to the need for an agile working approach during

--- a/map.html
+++ b/map.html
@@ -23,6 +23,7 @@
     <script src="https://unpkg.com/d3-regression@1.3.4/dist/d3-regression.min.js"></script>
     <script src="./frontend/map/js/cc.js"></script>
     <title>COVID-19 Community Response Map</title>
+    <link rel="shortcut icon" type="image/jpg" href="frontend/landing-page/img/logo-main-fav.png" />
   </head>
   <body>
     <div id="content">

--- a/user-guide.html
+++ b/user-guide.html
@@ -284,6 +284,11 @@
       </div>
       <div class="modal-body">
         <p>
+          Datblygwyd y wefan hon gan Brifysgol Bryste gydag adborth gan Iechyd Cyhoeddus Cymru; nid yw’n eiddo
+          i Iechyd Cyhoeddus Cymru ac felly’n cadw at Safonau’r Gymraeg. Fodd bynnag, mae fersiwn Cymraeg yn cael
+          ei ddatblygu.  Oherwydd yr angen am ymagwedd hyblyg tuag at waith yn ystod y cyfnod digynsail hwn, caiff
+          ei phrofi a’i chyhoeddi yn dilyn adborth ac ar ôl mireinio’r wefan bresennol.
+          <hr></hr>
           This website has been developed by the University of Bristol with feedback from Public Health Wales;
           it does not belong to Public Health Wales and so does not currently observe the Welsh Language Standards.
           However, a Welsh language version is in development. Due to the need for an agile working approach during


### PR DESCRIPTION
This PR parameterises the map sidebar width across js and css, making it possible to offer different side bar widths to different devices dependent on screen size.

I've used this to give a narrower side bar to mobile platforms where the upright screen is narrower than 400px. This shrinks in three steps (400px, 360px, 320px), supporting back to iPhone 5 (in terms of screen width, at least).

And now there's a wider 440px side bar for screens at least twice that width.

I've also stopped parallax scrolling of the landing page backgrounds for most tablets as well as mobile, because it doesn't render correctly on mobile devices.