### PR TITLE
Bug fix for sidebar width

### DIFF
--- a/frontend/map/css/map.css
+++ b/frontend/map/css/map.css
@@ -15,19 +15,19 @@
 
 /* Narrow sidebar for mobile */
 /* @media only screen and (max-device-width: 576px) { */
-@media only screen and (max-device-width: 879px) {
+@media only screen and (max-width: 879px) {
   :root {
     --sidebar-width: 400px;
   }
 }
 
-@media only screen and (max-device-width: 399px) {
+@media only screen and (max-width: 399px) {
   :root {
     --sidebar-width: 360px;
   }
 }
 
-@media only screen and (max-device-width: 359px) {
+@media only screen and (max-width: 359px) {
   :root {
     --sidebar-width: 320px;
   }


### PR DESCRIPTION
This PR fixes a bug where widths determined by javascript did not match widths determined by CSS, by making sure both reference the width of the viewport rather than the device.