### PR TITLE
Updates to Cymraeg site

### DIFF
--- a/canllaw-i-ddefnyddwyr.html
+++ b/canllaw-i-ddefnyddwyr.html
@@ -212,21 +212,13 @@
 
     <div class="container" id="footer">
       <div class="row">
-        <div class="copyright col-12 col-md-4">
+        <div class="copyright col-12 col-md-6">
           <div class="centered">
             <p>Hawlfraint y Safle &copy; <a href="https://dynamicgenetics.org">Dynamic
                 Genetics Lab</a>, 2020</p>
           </div>
         </div>
-        <div class="langStatement col-12 col-md-4">
-          <div class="centered">
-            <p><a href="#" id="welshLangStatement" role="button" data-toggle="modal" data-target="#welsh-lang-modal"
-                aria-haspopup="true" aria-expanded="false">Datganiad y
-                Gymraeg</a>
-            </p>
-          </div>
-        </div>
-        <div class="image-attribution col-12 col-md-4">
+        <div class="image-attribution col-12 col-md-6">
           <div class="centered">
             <p>Delweddau canllaw gan <a href="https://dynamicgenetics.org">Dynamic
                 Genetics Lab</a>; delweddau eraill gan

--- a/canllaw-i-ddefnyddwyr.html
+++ b/canllaw-i-ddefnyddwyr.html
@@ -4,10 +4,10 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="Mapping the Community Response to COVID-19 in Wales">
+    <meta name="description" content="Mapio’r Ymateb Cymunedol i COVID-19 yng Nghymru">
     <meta name="author" content="The Dynamic Genetics Lab">
     <meta name="generator" content="Jekyll v4.0.1">
-    <title>COVID-19 Community Response</title>
+    <title>Map Ymateb COVID-19</title>
     <link rel="shortcut icon" type="image/jpg" href="frontend/landing-page/img/logo-main-fav.png" />
 
     <!-- Bootstrap core CSS -->

--- a/canllaw-i-ddefnyddwyr.html
+++ b/canllaw-i-ddefnyddwyr.html
@@ -40,7 +40,7 @@
             <a class="nav-link" href="./map.html">Map</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="./user-guide.html">Canllaw i Ddefnyddwyr</a>
+            <a class="nav-link" href="./canllaw-i-ddefnyddwyr.html">Canllaw i Ddefnyddwyr</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#team">Y tîm</a>

--- a/canllaw-i-ddefnyddwyr.html
+++ b/canllaw-i-ddefnyddwyr.html
@@ -129,7 +129,7 @@
             <p>Mae’r ochr dde ar waelod y graff yn adlewyrchu ardaloedd ag angen uchel a chymorth isel, tra bod y brig
               yn adlewyrchu ardaloedd ag angen isel a chymorth uchel.</p>
             <p>Felly ardaloedd gerllaw ochr dde gwaelod y graff sydd â’r <span class="need">coch</span> mwyaf dwys, tra
-              bod y rheiny gerllaw ochr chwith brig y graff sydd â’r <span class="support">blue</span>.</p>
+              bod y rheiny gerllaw ochr chwith brig y graff sydd â’r <span class="support">glas</span> mwyaf dwys.</p>
             <p>Mae’r llinell lwyd, letraws ar y graff yn dangos y duedd o ran y ffordd y mae’r ddau fesur yn
               gysylltiedig. Mae llinell o’r chwith isel i’r dde uchel yn awgrymu wrth i un gynyddu, bod y llall hefyd yn
               cynyddu; mae llinell o’r dde uchel i’r chwith isel yn awgrymu wrth i un gynyddu, bod y llall yn gostwng.

--- a/frontend/landing-page/css/variation.css
+++ b/frontend/landing-page/css/variation.css
@@ -172,7 +172,16 @@ span.need {
 }
 
 .logo-mapbox {
-  height: 50px;
+  height: 35px;
+}
+
+#thanks {
+  margin-top: 35px;
+}
+
+.message-mapbox {
+  color: grey;
+  font-size: small;
 }
 
 .centered {
@@ -196,7 +205,7 @@ span.need {
 }
 
 #footer {
-  padding-top: 10px;
+  padding-top: 60px;
 }
 
 #footer div {

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
                         <a class="nav-link" href="./map.html">Map</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="./user-guide.html">Canllaw i Ddefnyddwyr</a>
+                        <a class="nav-link" href="./canllaw-i-ddefnyddwyr.html">Canllaw i Ddefnyddwyr</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="#team">Y tîm</a>

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="Mapping the Community Response to COVID-19 in Wales">
+        <meta name="description" content="Mapio’r Ymateb Cymunedol i COVID-19 yng Nghymru">
         <meta name="author" content="The Dynamic Genetics Lab">
         <meta name="generator" content="Jekyll v4.0.1">
-        <title>COVID-19 Community Response</title>
+        <title>Map Ymateb COVID-19</title>
         <link rel="shortcut icon" type="image/jpg" href="frontend/landing-page/img/logo-main-fav.png" />
 
         <!-- Bootstrap core CSS -->

--- a/index.html
+++ b/index.html
@@ -188,18 +188,12 @@
                     </div>
 
                     <div class="col-12 col-sm-6 col-lg-4 centered">
-                        <a href="https://www.mapbox.com/community/" title="mapbox">
-                            <img src="frontend/landing-page/img/mapbox-logo-black.svg" alt="MapBox Community"
-                                class="logo-mapbox"></a>
-                    </div>
-
-                    <div class="col-12 col-sm-6 col-lg-4 centered">
                         <a href="https://www.turing.ac.uk/" title="Alan Turing Institute">
                             <img src="frontend/landing-page/img/logo-turing.png" alt="Alan Turing Institute"
                                 class="logo-height-equal"></a>
                     </div>
 
-                    <div class="col-12 centered">
+                    <div class="col-12 col-sm-6 col-lg-4 centered">
                         <a href="https://esrc.ukri.org/" title="Economic and Social Research Council">
                             <img src="frontend/landing-page/img/logo-esrc.png"
                                 alt="Economic and Social Research Council" class="logo-esrc"></a>
@@ -210,25 +204,34 @@
                 </div>
             </div>
 
+            <div class="container" id="thanks">
+                <div class="row">
+                    <div class="col-12 centered">
+                        <a href="https://www.mapbox.com/community/" title="mapbox">
+                            <img src="frontend/landing-page/img/mapbox-logo-black.svg" alt="MapBox Community"
+                                class="logo-mapbox" />
+                        </a>
+                    </div>
+                    <div class="message-mapbox col-12 col-md-4 offset-md-4" style="padding-top: 15px;">
+                        Special thanks to the Mapbox Community team for
+                        subsidised access to the Mapbox application programming interface
+                    </div>
+                </div>
+            </div>
+
+            <br />
+
         </main>
 
         <div class="container" id="footer">
             <div class="row">
-                <div class="copyright col-12 col-md-4">
+                <div class="copyright col-12 col-md-6">
                     <div class="centered">
                         <p>Hawlfraint y Safle &copy; <a href="https://dynamicgenetics.org">Dynamic
                                 Genetics Lab</a>, 2020</p>
                     </div>
                 </div>
-                <div class="langStatement col-12 col-md-4">
-                    <div class="centered">
-                        <p><a href="#" id="welshLangStatement" role="button" data-toggle="modal"
-                                data-target="#welsh-lang-modal" aria-haspopup="true" aria-expanded="false">Datganiad y
-                                Gymraeg</a>
-                        </p>
-                    </div>
-                </div>
-                <div class="image-attribution col-12 col-md-4">
+                <div class="image-attribution col-12 col-md-6">
                     <div class="centered">
                         <p>Delweddau canllaw gan <a href="https://dynamicgenetics.org">Dynamic
                                 Genetics Lab</a>; delweddau eraill gan

--- a/index.html
+++ b/index.html
@@ -52,6 +52,9 @@
                         </a>
                         <div class="dropdown-menu" aria-labelledby="navbarDropdown"></div>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="https://covidresponsemap.wales/">English</a>
+                    </li>
                 </ul>
             </div>
         </nav>
@@ -287,48 +290,6 @@
                         <h6>Dogfennau côd Ymateb Cymunedol COVID-19</h6>
                     </a>
 
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">
-                        Yn ôl
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Welsh language modal -->
-    <div class="modal fade" id="welsh-lang-modal" tabindex="-1" role="dialog" aria-labelledby="modalCenterTitle"
-        aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="modalLongTitleWelsh">Datganiad y Gymraeg</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <p>
-                        Datblygwyd y wefan hon gan Brifysgol Bryste gydag adborth gan Iechyd
-                        Cyhoeddus Cymru; nid yw’n eiddo
-                        i Iechyd Cyhoeddus Cymru ac felly’n cadw at Safonau’r Gymraeg. Fodd
-                        bynnag, mae fersiwn Cymraeg yn cael
-                        ei ddatblygu. Oherwydd yr angen am ymagwedd hyblyg tuag at waith yn
-                        ystod y cyfnod digynsail hwn, caiff
-                        ei phrofi a’i chyhoeddi yn dilyn adborth ac ar ôl mireinio’r wefan
-                        bresennol.
-                        <hr />
-                        This website has been developed by the University of Bristol with
-                        feedback from Public Health Wales;
-                        it does not belong to Public Health Wales and so does not currently
-                        observe the Welsh Language Standards.
-                        However, a Welsh language version is in development. Due to the need for
-                        an agile working approach during
-                        these unprecedented times, it will be tested and published following
-                        feedback and refinement of
-                        the current website.
-                    </p>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">

--- a/user-guide.html
+++ b/user-guide.html
@@ -52,6 +52,9 @@
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown"></div>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://covidresponsemap.wales/">English</a>
+          </li>
         </ul>
       </div>
     </nav>
@@ -295,37 +298,5 @@
     </div>
   </div>
 
-  <!-- Welsh language modal -->
-  <div class="modal fade" id="welsh-lang-modal" tabindex="-1" role="dialog" aria-labelledby="modalCenterTitle"
-    aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="modalLongTitleWelsh">Datganiad y Gymraeg</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <p>
-            Datblygwyd y wefan hon gan Brifysgol Bryste gydag adborth gan Iechyd Cyhoeddus Cymru; nid yw’n eiddo
-            i Iechyd Cyhoeddus Cymru ac felly’n cadw at Safonau’r Gymraeg. Fodd bynnag, mae fersiwn Cymraeg yn cael
-            ei ddatblygu. Oherwydd yr angen am ymagwedd hyblyg tuag at waith yn ystod y cyfnod digynsail hwn, caiff
-            ei phrofi a’i chyhoeddi yn dilyn adborth ac ar ôl mireinio’r wefan bresennol.
-            <hr>
-            </hr>
-            This website has been developed by the University of Bristol with feedback from Public Health Wales;
-            it does not belong to Public Health Wales and so does not currently observe the Welsh Language Standards.
-            However, a Welsh language version is in development. Due to the need for an agile working approach during
-            these unprecedented times, it will be tested and published following feedback and refinement of
-            the current website.
-          </p>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">Yn ôl</button>
-        </div>
-      </div>
-    </div>
-  </div>
 
 </html>


### PR DESCRIPTION
**Changes:**
- Remove Welsh language modal text (link still in footer)
- Update <head> title and description to Welsh
- Changes user-guide filename to Welsh (so that link address is fully Welsh, not mixed english/welsh)
- Fixed a minor typo in the user guide where one word was still English. 
- Remove Welsh language statement link from footer
- Mapbox logo change reflects the one on the English site

Still need: 
- Translated text for how to get in contact and add your group to COVID-19 Mutual Aid